### PR TITLE
fix missing arguments for format string in logging

### DIFF
--- a/beanstream/transaction.py
+++ b/beanstream/transaction.py
@@ -179,7 +179,7 @@ class Transaction(object):
 
         '''print('Sending to ', 'https://www.beanstream.com'+self.url, data)'''
         
-        log.debug('Sending to ', 'https://www.beanstream.com'+self.url, data)
+        log.debug('Sending to %s: %s', self.url, data)
         request = Request('https://www.beanstream.com'+self.url)
         request.add_header('Authorization', passcode)
 


### PR DESCRIPTION
This makes debugging in `process_query_params` the same as in `process_rest`.

The arguments are unused in the basic python logging library because %s are missing, and thus are pointless.

In third party logging (logbook for example), this cause warnings to be emitted.
